### PR TITLE
Adding $USE_SYSTEM_CA_CERTS variable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,4 +42,9 @@ test "${ENABLE_UPDATE}" = true && sed -i 's/#\s*\(fuseki:serviceUpdate\)/\1/' $A
 test "${ENABLE_SHACL}" = true && sed -i -E 's/#\s*(fuseki:endpoint\s*\[\s*fuseki:operation\s+fuseki:shacl.+$)/\1/' $ASSEMBLER
 test "${QUERY_TIMEOUT}" && sed -i "s/\(ja:cxtName\s*\"arq:queryTimeout\"\s*;\s*ja:cxtValue\s*\)\"[0-9]*\"/\1\"$QUERY_TIMEOUT\"/" $CONFIG
 
-exec "$@"
+# Execute parent entrypoint to use system CA certificates
+if [ -n "$USE_SYSTEM_CA_CERTS" ] ; then
+  source /__cacert_entrypoint.sh
+else
+  exec "$@"
+fi


### PR DESCRIPTION
This will execute the `entrypoint.sh` of the parent image (available as `/__cacert_entrypoint.sh`) when `USE_SYSTEM_CA_CERTS` set to `1` in Docker env.
See https://github.com/adoptium/containers/blob/efeb51b1e88103abd826d1a3fc6521d3d696434b/11/jdk/alpine/entrypoint.sh#L32

With this addition it is possible to mount an CA to the Docker container and let Java / Fuseki use them.
It is necessary to do this when a RDF file is downloaded from a server with a self-signed certificate.